### PR TITLE
Fix mobile confirmation styling and make dropdown close on cancel

### DIFF
--- a/src/components/mobile/mobileTimeslot.tsx
+++ b/src/components/mobile/mobileTimeslot.tsx
@@ -148,6 +148,7 @@ export default function MobileTimeslot({
             enabled={enabled}
             setRequery={setRequery}
             toggleValue={toggleValue}
+            setIsDropdownOpen={setIsDropdownOpen}
           />
         )}
       </Dropdown>

--- a/src/components/mobile/mobileTimeslotConfirmation.tsx
+++ b/src/components/mobile/mobileTimeslotConfirmation.tsx
@@ -258,8 +258,10 @@ export default function MobileTimeSlotConfirmation({
               slots. Are you sure you want to do this?
             </CenteredDescription>
             <BtnContainer>
-              <CancelBtn onClick={handleCancel}>Cancel</CancelBtn>
-              <SaveBtn onClick={handleConfirmationAdmin}>Confirm</SaveBtn>
+              <MobileCancelBtn onClick={handleCancel}>Cancel</MobileCancelBtn>
+              <MobileSaveBtn onClick={handleConfirmationAdmin}>
+                Confirm
+              </MobileSaveBtn>
             </BtnContainer>
           </Box>
         </Wrapper>

--- a/src/components/mobile/mobileTimeslotConfirmation.tsx
+++ b/src/components/mobile/mobileTimeslotConfirmation.tsx
@@ -17,10 +17,10 @@ const Wrapper = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 4%;
+  padding: 6%;
 `;
 
-const Box = styled.section`
+const Box = styled.div`
   border: solid 0.5px #c4c4c4;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   display: flex;
@@ -56,6 +56,14 @@ const BtnContainer = styled.div`
   align-items: center;
   padding-top: 40px;
   gap: 20px;
+`;
+
+const MobileCancelBtn = styled(CancelBtn)`
+  width: 50%;
+`;
+
+const MobileSaveBtn = styled(SaveBtn)`
+  width: 50%;
 `;
 
 function convertToYMD(date: Date) {
@@ -252,11 +260,13 @@ export default function MobileTimeSlotConfirmation({
             <CenteredDescription>
               {`You are choosing to ${
                 booked ? "cancel" : "book"
-              } one or more time slots. Are you sure you want to do this?`}
+              } a time slot. Are you sure you want to do this?`}
             </CenteredDescription>
             <BtnContainer>
-              <CancelBtn onClick={handleCancel}>Cancel</CancelBtn>
-              <SaveBtn onClick={handleConfirmationRV}>Confirm</SaveBtn>
+              <MobileCancelBtn onClick={handleCancel}>Cancel</MobileCancelBtn>
+              <MobileSaveBtn onClick={handleConfirmationRV}>
+                Confirm
+              </MobileSaveBtn>
             </BtnContainer>
           </Box>
         </Wrapper>

--- a/src/components/mobile/mobileTimeslotContent.tsx
+++ b/src/components/mobile/mobileTimeslotContent.tsx
@@ -8,7 +8,7 @@ import MobileTimeSlotConfirmation from "./mobileTimeslotConfirmation";
 import TimeslotSuccess from "../popup/timeslotSuccess";
 import AppointmentInfo from "../appointmentInfo";
 import { LazyUser } from "../../models";
-// height 380px so that it stays that height (right now height changes based on rendering of components)
+
 const BoxMobile = styled.div`
   border: solid 0.5px #c4c4c4;
   display: flex;
@@ -59,6 +59,7 @@ type TimeslotMobileContentProps = {
   enabled: boolean;
   setRequery: (requery: boolean) => void;
   toggleValue: string;
+  setIsDropdownOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export default function TimeslotMobileContent({
@@ -70,6 +71,7 @@ export default function TimeslotMobileContent({
   enabled,
   setRequery,
   toggleValue,
+  setIsDropdownOpen,
 }: TimeslotMobileContentProps) {
   const currentUserFR = useContext(UserContext);
   const { currentUser } = currentUserFR;
@@ -91,6 +93,7 @@ export default function TimeslotMobileContent({
   const handleCancelled = () => {
     setSuccessShown(false);
     setConfirmationShown(false);
+    setIsDropdownOpen(false);
   };
 
   return (
@@ -117,7 +120,7 @@ export default function TimeslotMobileContent({
           </BoxMobileContent>
         )}
         {confirmationShown && !successShown && (
-          <BoxMobileContent>
+          <WrapperMobile>
             <MobileTimeSlotConfirmation
               handleClicked={handleSuccessShown}
               handleCancelled={handleCancelled}
@@ -127,7 +130,7 @@ export default function TimeslotMobileContent({
               tId={tId}
               setRequery={setRequery}
             />
-          </BoxMobileContent>
+          </WrapperMobile>
         )}
         {confirmationShown && successShown && (
           <TimeslotSuccess handleCancelled={handleCancelled} />


### PR DESCRIPTION
## Developer: Bora Joo

### Pull Request Summary

Mobile confirmation no longer bleeds out of box, and "cancel" and "return to calendar" closes the dropdown as a small UX change

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Ask for a review in communication channels

### Reviewer Checklist - PULL REQUEST REVIEWER ONLY

IMPORTANT: The rest of the sections in this checklist should only be filled out by authorized pull request reviewers. If you are the individual contributor, do not fill out the rest of the fields or check the boxes.

## Reviewer: Full Name

NOTE: Pull requests should only be merged when all boxes are checked.

- [ ] Assign yourself as reviewer if not assigned
- [ ] The reviewer name is specified
- [ ] The code is fully reviewed
- [ ] Meaningful feedback is given
- [ ] Let developer know a review has been made
